### PR TITLE
ci: stocker les geojson dans le projets

### DIFF
--- a/.github/workflows/trajectoires_pointages_daily_release.yml
+++ b/.github/workflows/trajectoires_pointages_daily_release.yml
@@ -81,6 +81,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: generated-file
+
       - name: Clean up old files
         run: |
           mkdir -p data
@@ -88,9 +93,9 @@ jobs:
 
       - name: Move new files to data folder
         run: |
-          mkdir -p data
-          mv ${{ env.FILE_NAME2 }}.geojson data/pointages.geojson
-          mv ${{ env.FILE_NAME3 }}.geojson data/trajectoire.geojson
+          mv output/${{ env.FILE_NAME2 }}.geojson data/pointages.geojson
+          mv output/${{ env.FILE_NAME3 }}.geojson data/trajectoire.geojson
+
       - name: Commit and push changes
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/trajectoires_pointages_daily_release.yml
+++ b/.github/workflows/trajectoires_pointages_daily_release.yml
@@ -89,9 +89,8 @@ jobs:
       - name: Move new files to data folder
         run: |
           mkdir -p data
-          mv pointages.geojson data/
-          mv trajectoire.geojson data/
-
+          mv ${{ env.FILE_NAME2 }}.geojson data/pointages.geojson
+          mv ${{ env.FILE_NAME3 }}.geojson data/trajectoire.geojson
       - name: Commit and push changes
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/trajectoires_pointages_daily_release.yml
+++ b/.github/workflows/trajectoires_pointages_daily_release.yml
@@ -71,3 +71,31 @@ jobs:
           mv ${{ env.FILE_NAME2 }}.geojson pointages.geojson
           mv ${{ env.FILE_NAME3 }}.geojson trajectoire.geojson
           gh release create latest latest_data.gpkg pointages.geojson trajectoire.geojson --title "Latest Data Daily Release" --notes "Automatically generated daily release"
+
+  update-files:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clean up old files
+        run: |
+          mkdir -p data
+          rm -f data/*.geojson
+
+      - name: Move new files to data folder
+        run: |
+          mkdir -p data
+          mv pointages.geojson data/
+          mv trajectoire.geojson data/
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/*.geojson
+          git diff --quiet && echo "No changes to commit" || git commit -m "Daily update: Update pointages and trajectoire files"
+          git push origin main

--- a/.github/workflows/trajectoires_pointages_daily_release.yml
+++ b/.github/workflows/trajectoires_pointages_daily_release.yml
@@ -88,8 +88,8 @@ jobs:
 
       - name: Clean up old files
         run: |
+          rm -rf data
           mkdir -p data
-          rm -f data/*.geojson
 
       - name: Move new files to data folder
         run: |
@@ -101,5 +101,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/*.geojson
-          git diff --quiet && echo "No changes to commit" || git commit -m "Daily update: Update pointages and trajectoire files"
+          git commit -m "Update pointages and trajectoire files"
           git push origin main

--- a/.github/workflows/trajectoires_pointages_daily_release.yml
+++ b/.github/workflows/trajectoires_pointages_daily_release.yml
@@ -93,8 +93,8 @@ jobs:
 
       - name: Move new files to data folder
         run: |
-          mv output/${{ env.FILE_NAME2 }}.geojson data/pointages.geojson
-          mv output/${{ env.FILE_NAME3 }}.geojson data/trajectoire.geojson
+          mv ${{ env.FILE_NAME2 }}.geojson data/pointages.geojson
+          mv ${{ env.FILE_NAME3 }}.geojson data/trajectoire.geojson
 
       - name: Commit and push changes
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -163,4 +163,3 @@ cython_debug/
 
 .data/*
 *.gpkg
-*.geojson


### PR DESCRIPTION
Le but est que chaque fois que la CI produit les données, les geojson sont stockés dans le dossier `data` du projet. Il écrasse ceux qui existe déja.